### PR TITLE
#1302 Add beakColor props to Callout

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -35,6 +35,12 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   beakWidth?: number;
 
   /**
+  * The color of the beak.
+  * @default #ffffff
+  */
+  beakColor?: string;
+
+  /**
    * The bounding rectangle for which  the contextual menu can appear in.
    */
   bounds?: IRectangle;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -34,6 +34,7 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
   public static defaultProps = {
     isBeakVisible: true,
     beakWidth: 16,
+    beakColor: "#ffffff",
     gapSpace: 16,
     directionalHint: DirectionalHint.bottomAutoEdge
   };
@@ -95,7 +96,8 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
       isBeakVisible,
       beakStyle,
       children,
-      beakWidth } = this.props;
+      beakWidth,
+      beakColor } = this.props;
     let { positions } = this.state;
     let beakStyleWidth = beakWidth;
 
@@ -109,7 +111,8 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
       top: positions && positions.beakPosition ? positions.beakPosition.top : BEAK_ORIGIN_POSITION.top,
       left: positions && positions.beakPosition ? positions.beakPosition.left : BEAK_ORIGIN_POSITION.left,
       height: beakStyleWidth,
-      width: beakStyleWidth
+      width: beakStyleWidth,
+      backgroundColor: beakColor
     };
 
     let directionalClassName = positions && positions.directionalClassName ? `ms-u-${positions.directionalClassName}` : '';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1302
- [ ] Include a change request file if publishing <!-- see notes below -->
- [x] enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Description of changes

This change add a beakColor props to Callout to allow modification of beak background color.
